### PR TITLE
Added --allowssidgroup option

### DIFF
--- a/wemosetup.py
+++ b/wemosetup.py
@@ -136,7 +136,7 @@ def connecthomenetwork(ssid, password, allowssidgroup):
 			'channel'  : channel
 		})
 		
-		time.sleep(2)
+		time.sleep(10)
 		
 		network_status = device.soap('WiFiSetup', 'GetNetworkStatus', 'NetworkStatus')
 		close_status = device.soap('WiFiSetup', 'CloseSetup', 'status')

--- a/wemosetup.py
+++ b/wemosetup.py
@@ -93,7 +93,7 @@ def discover():
 	print ''
 	return discovered_devices
 
-def connecthomenetwork(ssid, password, allowssidgroup):
+def connecthomenetwork(ssid, password):
 	def encrypt_wifi_password(password, meta_array):
 		keydata = meta_array[0][0:6] + meta_array[1] + meta_array[0][6:12]
 		salt, iv = keydata[0:8], keydata[0:16]
@@ -117,12 +117,8 @@ def connecthomenetwork(ssid, password, allowssidgroup):
 			print 'Could not find network "%s". Try again.' % ssid
 			continue
 		elif apCount > 1:
-			if allowssidgroup:
-				aps = [aps[0]]
-				print 'Using first matching SSID in network group "%s"' % ssid
-			else:
-				print 'Found more than one network with the name "%s". Use --allowssidgroup or adjust SSID.' % ssid
-				continue
+			print 'Discovered %d networks with SSID "%s", using the first available..."' % (apCount,ssid)
+			aps = [aps[0]]
 		channel, auth_mode, encryption_mode = re.match('.+\|(.+)\|.+\|(.+)/(.+),', aps[0]).groups()
 		
 		meta_array = device.soap('metainfo', 'GetMetaInfo', 'MetaInfo').split('|')
@@ -153,7 +149,6 @@ if __name__ == '__main__':
 	cmd = subparsers.add_parser('connecthomenetwork')
 	cmd.add_argument('--ssid', required = True)
 	cmd.add_argument('--password', required = True)
-	cmd.add_argument('--allowssidgroup', required = False)
 	cmd.set_defaults(func = connecthomenetwork)
 	
 	subparsers.add_parser('discover').set_defaults(func = discover)


### PR DESCRIPTION
 - Added --allowssidgroup option which allows setting up a connection to an SSID with duplicate networks. Default False.

 - Also increased duration when device tries to connect to a network. 2 seconds was not sufficient at all for any of my devices. Each took approximately 8 seconds. 10 seconds should be sufficient without adding retry functionality.